### PR TITLE
chore(FIN-1073): add opslevel annotations for keda related resources

### DIFF
--- a/namespaced/metrics-apiserver/deployment.yaml
+++ b/namespaced/metrics-apiserver/deployment.yaml
@@ -30,6 +30,12 @@ metadata:
     app.kubernetes.io/part-of: keda-operator
     app.kubernetes.io/version: 2.6.1
   name: keda-metrics-apiserver
+  annotations:
+    "app.uw.systems/description": "Kubernetes event-driven autoscaler API server."
+    "app.uw.systems/tier": "tier_2"
+    "app.uw.systems/repos.keda-manifests": "https://github.com/utilitywarehouse/keda-manifests/namespaced/metrics-apiserver"
+    "app.uw.systems/tags.oss": "true"
+    "app.uw.systems/tags.skip-repo": "true"
 spec:
   replicas: 1
   selector:
@@ -89,8 +95,8 @@ spec:
               name: temp-vol
       nodeSelector:
         kubernetes.io/os: linux
-#      securityContext:
-#        runAsNonRoot: true
+      #      securityContext:
+      #        runAsNonRoot: true
       serviceAccountName: keda-metrics-apiserver
       volumes:
         - emptyDir: {}

--- a/namespaced/operator/deployment.yaml
+++ b/namespaced/operator/deployment.yaml
@@ -28,6 +28,12 @@ metadata:
     app.kubernetes.io/part-of: keda-operator
     app.kubernetes.io/version: 2.6.1
   name: keda-operator
+  annotations:
+    "app.uw.systems/description": "Kubernetes event-driven autoscaler API operator."
+    "app.uw.systems/tier": "tier_2"
+    "app.uw.systems/repos.keda-manifests": "https://github.com/utilitywarehouse/keda-manifests/namespaced/operator"
+    "app.uw.systems/tags.oss": "true"
+    "app.uw.systems/tags.skip-repo": "true"
 spec:
   replicas: 1
   selector:
@@ -87,7 +93,7 @@ spec:
             readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
-#      securityContext:
-#        runAsNonRoot: true
+      #      securityContext:
+      #        runAsNonRoot: true
       serviceAccountName: keda-operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Noticed this repo contained some manifests and they don't have any OpsLevel annotations, so added them here.

https://app.opslevel.com/services/keda-operator
https://app.opslevel.com/services/keda-metrics-apiserver