### PR TITLE
DENA-1405 keda down due to certificate expiry: increase the validity of the CA cert

### DIFF
--- a/kube-system/clusterissuer/clusterissuer.yaml
+++ b/kube-system/clusterissuer/clusterissuer.yaml
@@ -16,6 +16,8 @@ spec:
   secretName: keda-selfsigned-ca
   commonName: keda
   isCA: true
+  duration: 4320h # 6 months
+  renewBefore: 2160h # 3 months
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer


### PR DESCRIPTION
Using workaround https://github.com/cert-manager/cert-manager/issues/5851#issuecomment-2413359368.

The certificates issued by this CA, the ones used by the keda components, are renewed at 2 months.